### PR TITLE
Fix merge conflicts

### DIFF
--- a/SCRIPT_NONSHINY.R
+++ b/SCRIPT_NONSHINY.R
@@ -8,7 +8,7 @@ if (1 ==0) {
   # and note that right now batch.summarizer::ejscreenapi() is in that package not here
 
   # and see  census2020download::blocks2020  for newer census data on blocks but may move to EJAM-Blockdata?
-  
+
   # and facilities_prep may be obsolete or should be done before save that as dataset and build a package.
 
 
@@ -49,7 +49,7 @@ if (1 ==0) {
   # blockwts
 
   # call function that finds nearby blocks  ####
-
+  localtree <- SearchTrees::createTree(quaddata, treeType = "quad", dataType = "point")
   system.time({
     # results_by_site <- summarizeForFacilities(
 
@@ -60,7 +60,9 @@ if (1 ==0) {
       cutoff = radius,
       maxcutoff = maxcutoff,
       uniqueonly = uniqueonly,
-      avoidorphans = avoidorphans
+      avoidorphans = avoidorphans,
+      tree = localtree
+
     )
   }
   )

--- a/SCRIPT_NONSHINY.R
+++ b/SCRIPT_NONSHINY.R
@@ -2,57 +2,57 @@
 # **** as written currently, presumes that other data are in global environment, ****
 # **** like blockgroupstats, blockdata, quaddata, etc. ****
 if (1 ==0) {
-  
+
   # See details in help for ?EJAM
-  
+
   # and note that right now batch.summarizer::ejscreenapi() is in that package not here
-  
+
   # and see  census2020download::blocks2020  for newer census data on blocks but may move to EJAM-Blockdata?
   
   # and facilities_prep may be obsolete or should be done before save that as dataset and build a package.
-  
-  
+
+
   # setup parameters, functions ####
   # - get data by loading package and some constants etc.
   # includes library(EJAM) which provides datasets like blockgroupstats, facilities, etc.
   library(blockdata) # may move it to EJAM-Census2020download
   library(EJAM)
   library(data.table)
-  
+
   CountCPU <- 2
   indexgridsize <- 10  # This does not seem to be used ever - it is just used to create buffer_indexdistance which is not used.
-  
+
   # can specify random test points (sites) ######
   #sitepoints <- points100example %>% head(1)# data in this package
-  
+
   sitepoints <- data.table::copy(EJAM::points1000example)
   # sitepoints <- data.table::copy(EJAM::points100example)   # NOTE the first point is far outside the continental US and returns no data using census 2010 blocks.
   sitepoints[ , siteid := .I]
   data.table::setnames(sitepoints, 'LAT', 'lat')
   data.table::setnames(sitepoints, 'LONG', 'lon')
   data.table::setkey(sitepoints) #,  c('siteid', 'lat', 'lon'))
-  
+
   # specify radius for circular buffer and other key parameters ####
-  
+
   radius <- 1 # radius (miles)
   maxcutoff <- 31.07 # 50 km  # max distance to expand search to (miles?)
   avoidorphans <- TRUE  # Expand distance searched, when a facility has no census block centroid within selected buffer distance
   uniqueonly <- FALSE    # TRUE = stats are for dissolved single buffer to avoid double-counting. FALSE = we want to count each person once for each site they are near.
-  
+
   ### IS THIS NEEDED? seems to be used only in the clustered version of getrelevant??
   # localtree <- blockquadtree
   #  localtree <- SearchTrees::createTree(blockdata::quaddata, treeType = "quad", dataType = "point")
-  
+
   # save.image('tempjunk.RData')
-  
+
   # blockdata[ , sum( , na.rm = TRUE), by = BLOCKGROUPFIPS]
   # blockwts
-  
+
   # call function that finds nearby blocks  ####
-  
+
   system.time({
     # results_by_site <- summarizeForFacilities(
-    
+
     # **** as written currently, presumes that other data are in global environment, ****
     # **** especially it uses quaddata ****
     sites2blocks <- getrelevantCensusBlocksviaQuadTree(
@@ -65,35 +65,35 @@ if (1 ==0) {
   }
   )
   # 1000 * 3600/13
-  
+
   # # call function that aggregates in each buffer  ####
-  # 
+  #
   # system.time(
-  # 
+  #
   #   # **** as written currently, presumes that other data are in global environment, ****
   #   # *** this uses blockdata and blockgroupstats ***
-  # 
+  #
   #   results_by_site <- doaggregate(sitepoints, results)
   # )
-  # 
+  #
   # # see results ####
-  # 
+  #
   # head(results_by_site)
-  
+
     # ej_api_results <- ejscreenapi(sitepoints$LONG[1:10], sitepoints$LAT[1:10], radius = 1)
   #   #ej_api_results <- batch.summarizer::ejscreenapi(sitepoints$LONG, sitepoints$LAT, radius = 1)
-  
-  # 
+
+  #
   # ej_api_results <- ej_api_results %>%
   #   dplyr::relocate(
   #     c(lon, lat),
   #     .before = RAW_E_PM25
   #   )
-  # 
+  #
   # ej_pop <- sum(as.numeric(ej_api_results$totalPop))
   # ej_pop
-  # 
+  #
   # quadtree_pop <- sum(results$POP100)
   # quadtree_pop
-  
+
 }

--- a/SCRIPT_NONSHINY.R
+++ b/SCRIPT_NONSHINY.R
@@ -25,7 +25,7 @@ if (1 ==0) {
   # can specify random test points (sites) ######
   #sitepoints <- points100example %>% head(1)# data in this package
 
-  sitepoints <- data.table::copy(EJAM::points1000example)
+  sitepoints <- data.table::copy(EJAM::points100example)
   # sitepoints <- data.table::copy(EJAM::points100example)   # NOTE the first point is far outside the continental US and returns no data using census 2010 blocks.
   sitepoints[ , siteid := .I]
   data.table::setnames(sitepoints, 'LAT', 'lat')
@@ -61,7 +61,7 @@ if (1 ==0) {
       maxcutoff = maxcutoff,
       uniqueonly = uniqueonly,
       avoidorphans = avoidorphans,
-      tree = localtree
+      quadtree = localtree
 
     )
   }

--- a/global.R
+++ b/global.R
@@ -34,6 +34,7 @@ library(SearchTrees)# efficient storage of block points info and selection of th
 library(data.table)  # faster than data.frame
 library(pdist)
 library(blockdata)
+library(frsdata)
 
 # library(doSNOW) ; library(foreach)  # parallel processing, efficient looping?
 # library(rgdal) ; library(maps) ; library(pdist) #?  # Geospatial tools

--- a/server.R
+++ b/server.R
@@ -170,7 +170,7 @@ shinyServer(function(input, output, session) {
       maxcutoff = maxcutoff,
       uniqueonly = uniqueonly,
       avoidorphans = avoidorphans,
-      tree = localtree
+      quadtree = localtree
       )
     })
     system.time({


### PR DESCRIPTION
getRelevantCensusBlocksviaQuadTree.R works now

As far as I can tell, you can't store the quadtree datastructure created from "SearchTrees::createTree()" in the package, because it has a pointer to the tree in memory, so we must either create the tree in the function or pass a tree to the function. If we're going for speed, then passing the tree to the function is the fastest. 

doAggregate is broken in this branch, but I understand it was still in progress at this point. 

I seem to have made this request after @ejanalysis created getrelevent...2 and doaggregate2, so we'll need to merge these... 
